### PR TITLE
Corrige cálculo de `raddress` para alinhamento de palavra

### DIFF
--- a/design/datamemory.sv
+++ b/design/datamemory.sv
@@ -29,7 +29,7 @@ module datamemory #(
   );
 
   always_ff @(*) begin
-    raddress = {{22{1'b0}}, a};
+    raddress = {{22{1'b0}}, {a[8:2], {2{1'b0}}}};
     waddress = {{22{1'b0}}, {a[8:2], {2{1'b0}}}};
     Datain = wd;
     Wr = 4'b0000;


### PR DESCRIPTION
## O `raddress` e o `waddress` indicam para o módulo `Memoria32data` a posição inicial da leitura ou escrita, que deve ser _word-aligned_, ou seja, múltipla de 4.

Antes da correção, o `datamemory.sv` estava enviando um endereço **sem alinhar** os dois bits menos significativos. Isso fazia com que o `Memoria32data` interpretasse o início da palavra em um endereço incorreto (por exemplo, 5 em vez de 4).

Como consequência, o case que tratava o deslocamento dentro da palavra usava um `offset` errado — por exemplo, se o endereço fosse 14, ele considerava o início da palavra no 14 em vez do 12, e aplicava o desvio a partir daí.
Isso fazia com que o módulo lesse bytes fora do lugar (como o endereço 16 em vez do 14), resultando em valores incorretos — _geralmente zero quando a posição não tinha dado válido_.

A correção foi alinhar o `raddress` exatamente como o `waddress`, ignorando os dois bits menos significativos (`a[1:0]`) para garantir acesso sempre a endereços múltiplos de 4.
